### PR TITLE
Disable tp for shared experts on rocm

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -300,7 +300,7 @@ class DeepseekV2MoE(nn.Module):
                 prefix=add_prefix("shared_experts", prefix),
                 **(
                     dict(tp_rank=0, tp_size=1)
-                    if global_server_args_dict["enable_deepep_moe"]
+                    if _is_hip or global_server_args_dict["enable_deepep_moe"]
                     else {}
                 ),
             )


### PR DESCRIPTION
This PR disables TP for shared experts on rocm platform, it supports running TP/EP MoE separately without DeepEP.
sglang fails when tp size > 16 and fp8 quantization is enabled. This is due to sharding of shared experts which reduces their size below fp8 quantization block size causing the error. The shared expert tp is currently disabled only when deepep is enabled, this PR disables it on rocm to allow seamless running of different paths individually.